### PR TITLE
[Hotfix] Prefer config's siteUrl if it's a string

### DIFF
--- a/src/controllers/SitemapController.php
+++ b/src/controllers/SitemapController.php
@@ -84,6 +84,7 @@ class SitemapController extends Controller
 
         $siteurl = isset(Craft::$app->config->general)
                 && isset(Craft::$app->config->general->siteUrl)
+                && gettype(Craft::$app->config->general->siteUrl) === 'string'
             ? Craft::$app->config->general->siteUrl
             : null;
 


### PR DESCRIPTION
Per https://github.com/craftcms/cms/blob/d26e74e5345fc4070a5730bc726d5a03d45c00a1/src/config/GeneralConfig.php#L608 -- siteUrl can be either a string or an array. 

So adding a check to only use config's siteUrl if it's a string, multisite support can be added later.