### PR TITLE
Moved `\Craft::$app->user->identity` into the event handler

### DIFF
--- a/src/Sitemap.php
+++ b/src/Sitemap.php
@@ -80,6 +80,10 @@ class Sitemap extends Plugin
 
     public function registerCpUrlRules(RegisterUrlRulesEvent $event)
     {
+        // only register CP URLs if the user is logged in
+        if (!\Craft::$app->user->identity)
+            return;
+        
         $rules = [
 
             // register routes for the settings tab
@@ -107,15 +111,13 @@ class Sitemap extends Plugin
     {
         parent::init();
         self::$plugin = $this;
-        // only register CP URLs if the user is logged in
-        if (\Craft::$app->user->identity) {
-            // Register our CP routes
-            Event::on(
-                UrlManager::class,
-                UrlManager::EVENT_REGISTER_CP_URL_RULES,
-                [$this, 'registerCpUrlRules']
-            );
-        }
+        
+        // Register our CP routes
+        Event::on(
+            UrlManager::class,
+            UrlManager::EVENT_REGISTER_CP_URL_RULES,
+            [$this, 'registerCpUrlRules']
+        );
 
         // Register our site routes
         Event::on(


### PR DESCRIPTION
A fix for ethercreative/simplemap#84.

Calling `\Craft::$app->user->identity` [loads up a bunch of stuff](https://github.com/am-impact/amcommand/issues/33#issuecomment-351994393) which can cause issues if plugins are loaded in a certain order. Moving the check to within the event handler fixes this issue.