### PR TITLE
Filter out deleted sections and draft elements

### DIFF
--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -72,6 +72,7 @@ class SettingsController extends Controller
             ->leftJoin('{{%dolphiq_sitemap_entries}} sitemap_entries', '[[sections.id]] = [[sitemap_entries.linkId]] AND [[sitemap_entries.type]] = "section"')
 
             ->groupBy(['sections.id'])
+            ->where(['sections.dateDeleted' => null])
         ->orderBy(['type' => SORT_ASC],['name' => SORT_ASC]);
     }
 

--- a/src/controllers/SitemapController.php
+++ b/src/controllers/SitemapController.php
@@ -173,6 +173,7 @@ class SitemapController extends Controller
             ->innerJoin('{{%sites}} sites', '[[elements_sites.siteId]] = [[sites.id]]')
             ->andWhere(['elements.dateDeleted' => null])
             ->andWhere(['elements.archived' => false])
+            ->andWhere(['elements.draftId' => null])
             ->andWhere(['elements.revisionId' => null])
 
 


### PR DESCRIPTION
After encountering issue #41 myself, I took a dive into the queries and tried to solve them. This fixes any deleted sections showing up on the settings form and draft entries showing up in the generated sitemap.