### PR TITLE
Fix and/or operation order

### DIFF
--- a/src/controllers/SitemapController.php
+++ b/src/controllers/SitemapController.php
@@ -165,8 +165,7 @@ class SitemapController extends Controller
                 '[[sections_sites.sectionId]] = [[sections.id]] AND [[sections_sites.hasUrls]] = 1')
             ->innerJoin('{{%entries}} entries', '[[sections.id]] = [[entries.sectionId]]')
             ->andWhere(['<=', 'entries.postDate', $currentDate])
-            ->andWhere(['>', 'entries.expiryDate', $currentDate])
-            ->orWhere(['entries.expiryDate'=> null])
+            ->andWhere(['or', 'entries.expiryDate > :currentDate', 'entries.expiryDate is null'], [':currentDate' => $currentDate])
             ->innerJoin('{{%elements}} elements', '[[entries.id]] = [[elements.id]] AND [[elements.enabled]] = 1')
             ->innerJoin('{{%elements_sites}} elements_sites',
                 '[[elements_sites.elementId]] = [[elements.id]] AND [[elements_sites.enabled]] = 1')


### PR DESCRIPTION
There is an issue with entries that have no expiry date but are not yet posted showing up in the sitemap.
The orWhere needs to only be affecting the expiry date check where as currently anything with a null expiry date is shown, overriding the postDate check.