### PR TITLE
Correct case namespace

### DIFF
--- a/src/assetbundles/sitemap/SitemapAsset.php
+++ b/src/assetbundles/sitemap/SitemapAsset.php
@@ -8,7 +8,7 @@
  * @copyright Copyright (c) 2017 Johan Zandstra
  */
 
-namespace dolphiq\sitemap\assetbundles\Sitemap;
+namespace dolphiq\sitemap\assetbundles\sitemap;
 
 use Craft;
 use craft\web\AssetBundle;


### PR DESCRIPTION
This makes it so that later versions of composer do not skip this plugin.

Fixes #52 